### PR TITLE
Allow skipping SSL cert verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Docker 版本通过与 Config 相同名称的环境变量配置, 通过自动转
 | qBUsername | 空 | qBittorrent Web UI 账号. 若启用 qBittorrent 内 "跳过本机客户端认证" 可默认留空, 可自动读取 qBittorrent 配置文件并设置 |
 | qBPassword | 空 | qBittorrent Web UI 密码. 若启用 qBittorrent 内 "跳过本机客户端认证" 可默认留空 |
 | blockList | 空 (于 config.json 附带) | 屏蔽客户端列表. 同时判断 PeerID 及 UserAgent, 不区分大小写, 支持正则表达式 |
+| tlsSkipCertVerification | false | 跳过qBittorrent WebUI证书校验, 适合https+自签证书 |
 
 ## 致谢 Credit
 1. 我们在客户端屏蔽器的早期开发过程中部分参考了 [jinliming2/qbittorrent-ban-xunlei](https://github.com/jinliming2/qbittorrent-ban-xunlei);

--- a/config.go
+++ b/config.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"os"
-	"flag"
-	"time"
-	"regexp"
-	"reflect"
-	"strings"
-	"strconv"
-	"io/ioutil"
+	"crypto/tls"
 	"encoding/json"
+	"flag"
+	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type ConfigStruct struct {
@@ -61,7 +62,7 @@ var configFilename string
 var configLastMod int64 = 0
 var qBConfigLastMod int64 = 0
 
-var httpTransport = &http.Transport {
+var httpTransport = &http.Transport{
 	DisableKeepAlives:   false,
 	ForceAttemptHTTP2:   false,
 	MaxConnsPerHost:     32,
@@ -69,12 +70,12 @@ var httpTransport = &http.Transport {
 	MaxIdleConnsPerHost: 32,
 	TLSClientConfig:     &tls.Config{InsecureSkipVerify: false},
 }
-var httpClient = http.Client {
+var httpClient = http.Client{
 	Timeout:   6 * time.Second,
 	Jar:       cookieJar,
 	Transport: httpTransport,
 }
-var config = ConfigStruct {
+var config = ConfigStruct{
 	Debug:                         false,
 	Debug_CheckTorrent:            false,
 	Debug_CheckPeer:               false,
@@ -112,38 +113,38 @@ var config = ConfigStruct {
 func GetQBConfigPath() string {
 	var qBConfigFilename string
 	userHomeDir, err := os.UserHomeDir()
-    if err != nil {
+	if err != nil {
 		Log("Debug-GetQBConfigPath", "获取 User Home 目录时发生了错误: %s", false, err.Error())
 		return ""
-    }
-    if !strings.Contains(userHomeDir, "\\") {
-    	qBConfigFilename = userHomeDir + "/.config/qBittorrent/qBittorrent.ini"
-    } else {
-	    userConfigDir, err := os.UserConfigDir()
-	    if err != nil {
+	}
+	if !strings.Contains(userHomeDir, "\\") {
+		qBConfigFilename = userHomeDir + "/.config/qBittorrent/qBittorrent.ini"
+	} else {
+		userConfigDir, err := os.UserConfigDir()
+		if err != nil {
 			Log("Debug-GetQBConfigPath", "获取 User Config 目录时发生了错误: %s", false, err.Error())
 			return ""
-	    }
-    	qBConfigFilename = userConfigDir + "\\qBittorrent\\qBittorrent.ini"
-    }
-    return qBConfigFilename
+		}
+		qBConfigFilename = userConfigDir + "\\qBittorrent\\qBittorrent.ini"
+	}
+	return qBConfigFilename
 }
 func GetConfigFromQB() []byte {
-    qBConfigFilename := GetQBConfigPath()
-    if qBConfigFilename == "" {
-    	return []byte {}
-    }
+	qBConfigFilename := GetQBConfigPath()
+	if qBConfigFilename == "" {
+		return []byte{}
+	}
 	qBConfigFileStat, err := os.Stat(qBConfigFilename)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			// 避免反复猜测默认 qBittorrent 配置文件的失败信息影响 Debug 用户体验.
 			Log("GetConfigFromQB", "读取 qBittorrent 配置文件元数据时发生了错误: %s", false, err.Error())
 		}
-		return []byte {}
+		return []byte{}
 	}
 	tmpQBConfigLastMod := qBConfigFileStat.ModTime().Unix()
 	if config.QBURL != "" && tmpQBConfigLastMod <= qBConfigLastMod {
-		return []byte {}
+		return []byte{}
 	}
 	Log("GetConfigFromQB", "使用 qBittorrent 配置文件: %s", false, qBConfigFilename)
 	if qBConfigLastMod != 0 {
@@ -152,7 +153,7 @@ func GetConfigFromQB() []byte {
 	qBConfigFile, err := ioutil.ReadFile(qBConfigFilename)
 	if err != nil {
 		Log("GetConfigFromQB", "读取 qBittorrent 配置文件时发生了错误: %s", false, err.Error())
-		return []byte {}
+		return []byte{}
 	}
 	qBConfigLastMod = tmpQBConfigLastMod
 	return qBConfigFile
@@ -176,29 +177,29 @@ func SetQBURLFromQB() bool {
 		qbConfigLineArr[0] = strings.ToLower(StrTrim(qbConfigLineArr[0]))
 		qbConfigLineArr[1] = strings.ToLower(StrTrim(qbConfigLineArr[1]))
 		switch qbConfigLineArr[0] {
-			case "webui\\enabled":
-				if qbConfigLineArr[1] == "true" {
-					qBWebUIEnabled = true
-				}
-			case "webui\\https\\enabled":
-				if qbConfigLineArr[1] == "true" {
-					qBHTTPSEnabled = true
-				}
-			case "webui\\address":
-				if qbConfigLineArr[1] == "*" || qbConfigLineArr[1] == "0.0.0.0" {
-					qBAddress = "127.0.0.1"
-				} else if qbConfigLineArr[1] == "::" || qbConfigLineArr[1] == "::1" {
-					qBAddress = "[::1]"
-				} else {
-					qBAddress = qbConfigLineArr[1]
-				}
-			case "webui\\port":
-				tmpQBPort, err := strconv.Atoi(qbConfigLineArr[1])
-				if err == nil {
-					qBPort = tmpQBPort
-				}
-			case "webui\\username":
-				qBUsername = qbConfigLineArr[1]
+		case "webui\\enabled":
+			if qbConfigLineArr[1] == "true" {
+				qBWebUIEnabled = true
+			}
+		case "webui\\https\\enabled":
+			if qbConfigLineArr[1] == "true" {
+				qBHTTPSEnabled = true
+			}
+		case "webui\\address":
+			if qbConfigLineArr[1] == "*" || qbConfigLineArr[1] == "0.0.0.0" {
+				qBAddress = "127.0.0.1"
+			} else if qbConfigLineArr[1] == "::" || qbConfigLineArr[1] == "::1" {
+				qBAddress = "[::1]"
+			} else {
+				qBAddress = qbConfigLineArr[1]
+			}
+		case "webui\\port":
+			tmpQBPort, err := strconv.Atoi(qbConfigLineArr[1])
+			if err == nil {
+				qBPort = tmpQBPort
+			}
+		case "webui\\username":
+			qBUsername = qbConfigLineArr[1]
 		}
 	}
 	if !qBWebUIEnabled || qBAddress == "" {
@@ -266,13 +267,13 @@ func InitConfig() {
 		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: false}
 	}
 	if !config.LongConnection {
-		httpClient = http.Client {
+		httpClient = http.Client{
 			Timeout:   time.Duration(config.Timeout) * time.Second,
 			Jar:       cookieJar,
 			Transport: httpTransport,
 		}
 	} else if config.Timeout != 6 {
-		httpClient = http.Client {
+		httpClient = http.Client{
 			Timeout:   time.Duration(config.Timeout) * time.Second,
 			Jar:       cookieJar,
 			Transport: httpTransport,
@@ -309,7 +310,7 @@ func LoadInitConfig(firstLoad bool) {
 	if firstLoad && config.QBURL == "" {
 		SetQBURLFromQB()
 	}
-	if config.QBURL != ""  {
+	if config.QBURL != "" {
 		if !firstLoad && lastQBURL != config.QBURL {
 			SubmitBlockPeer("")
 			lastQBURL = config.QBURL

--- a/config.json
+++ b/config.json
@@ -12,5 +12,6 @@
 	"qBURL": "",
 	"qBUsername": "",
 	"qBPassword": "",
+	"tlsSkipCertVerification": false,
 	"blockList": ["-(XL|SD|XF|QD|BN|DL)(\\d+)-", "((^(xunlei?).?\\d+.\\d+.\\d+.\\d+)|cacao_torrent)", "-(UW\\w{4}|SP(([0-2]\\d{3})|(3[0-5]\\d{2})))-", "StellarPlayer", "dandanplay", "anacrolix[ /]torrent v?([0-1]\\.(([0-9]|[0-4][0-9]|[0-5][0-2])\\.[0-9]+|(53\\.[0-2]( |$)))|unknown)"]
 }


### PR DESCRIPTION
Thank you for your great work. What I encounter is, my qBittorrent exposes https port directly rather than behind a reverse proxy, and its certificate expired long time ago : ) so the blocker alerts me "tls: failed to verify certificate: x509: certificate signed by unknown authority."

This PR simply adds a config item to allow skipping SSL certificate verification.