### PR TITLE
Block List Add "\u07ad__"

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,8 @@
 		"^-DT", "dt[ /]torrent",
 		"trafficConsume",
 		"go[ \\.]torrent",
-		"Taipei-Torrent dev"
+		"Taipei-Torrent dev",
+		"\u07ad__"
 	],
 	"_blockList": [ // 可选 blockList, 合并以屏蔽媒体播放器.
 		"^-(UW\\w{4}-", // uTorrent Web.


### PR DESCRIPTION
在 Debian 的 DVD 镜像中遇到了这样的客户端
<img width="1170" alt="image" src="https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/assets/20148769/efb12091-86fa-4ce9-a56b-007399435d7b">

其他人也有遇到：
https://github.com/anacrolix/torrent/discussions/891#discussioncomment-9021507
https://github.com/c0re100/qBittorrent-Enhanced-Edition/issues/530#issuecomment-2007555084