### PR TITLE
在 Dockerfile 中使用 entrypoint.sh 的绝对路径

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY --from=go /app ./
 RUN chmod +x ./entrypoint.sh
 RUN apk update && apk add --no-cache jq socat
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
使用 docker compose 配置方式时会出现以下报错：
`Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./entrypoint.sh": stat ./entrypoint.sh: no such file or directory: unknown`
指定绝对路径可解决该问题