### PR TITLE
Fix a bug that reloading config will drop URL block records.

### DIFF
--- a/config.go
+++ b/config.go
@@ -519,12 +519,14 @@ func InitConfig() {
 	}
 
 	blockListCompiled = make(map[string]*regexp2.Regexp)
+	blockListURLLastFetch = 0
 	SetBlockListFromContent(config.BlockList)
 	if errCount := len(config.BlockList) != len(blockListCompiled); errCount {
 		Log("LoadConfig_CompileBlockList", GetLangText("Error-CompileBlockList"), false, errCount)
 	}
 
 	ipBlockListCompiled = make(map[string]*net.IPNet, len(config.IPBlockList))
+	ipBlockListURLLastFetch = 0
 	SetIPBlockListFromContent(config.IPBlockList)
 	if errCount := len(config.IPBlockList) != len(ipBlockListCompiled); errCount {
 		Log("LoadConfig_CompileIPBlockList", GetLangText("Error-CompileIPBlockList"), false, errCount)


### PR DESCRIPTION
因配置文件时间戳变化导致的配置热更新，会使得来自URL的屏蔽条目全部丢失。这些丢失的条目要等到一个UpdateInterval之后才会被重新添加。
pr在配置热更，重新创建map时强制归零了URLLastFetch，以使得之后的Set*ListFromURL能够执行更新动作。