### PR TITLE
为QBittorrent Enhanced Edition用户提供enableShadowBan配置参数

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,13 +119,16 @@ func FetchTorrentPeers(infoHash string) interface{} {
 
 	return nil
 }
-func SubmitBlockPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
+func SubmitBlockPeer(blockPeerMap map[string]BlockPeerInfoStruct, useShadowBan bool) bool {
 	if blockPeerMap == nil {
 		return true
 	}
 
 	switch currentClientType {
 	case "qBittorrent":
+		if useShadowBan {
+			return qb_SubmitShadowbanPeers(blockPeerMap)
+		}
 		return qB_SubmitBlockPeer(blockPeerMap)
 	case "Transmission":
 		return Tr_SubmitBlockPeer(blockPeerMap)

--- a/config.go
+++ b/config.go
@@ -78,6 +78,7 @@ type ConfigStruct struct {
 	BanByRelativePUStartMB        uint32
 	BanByRelativePUStartPrecent   float64
 	BanByRelativePUAntiErrorRatio float64
+	EnableShadowBan               bool
 }
 
 var programName = "qBittorrent-ClientBlocker"
@@ -191,6 +192,7 @@ var config = ConfigStruct{
 	BanByRelativePUStartMB:        20,
 	BanByRelativePUStartPrecent:   2,
 	BanByRelativePUAntiErrorRatio: 3,
+	EnableShadowBan:               false,
 }
 
 func SetBlockListFromContent(blockListContent []string) int {
@@ -565,7 +567,7 @@ func LoadInitConfig(firstLoad bool) bool {
 			if firstLoad && !Login() {
 				return false
 			}
-			SubmitBlockPeer(nil)
+			SubmitBlockPeer(nil, false)
 			lastURL = config.ClientURL
 		}
 	} else {

--- a/config.json
+++ b/config.json
@@ -65,7 +65,8 @@
 		"https://bta.iaalai.cn/BTN-Collected-Rules/combine/all.txt",
     		"https://cdn.jsdelivr.net/gh/PBH-BTN/BTN-Collected-Rules@main/combine/all.txt"
 	],
-	"ipBlockListFile": []
+	"ipBlockListFile": [],
+	"enableShadowBan": true
 	/*
 	"debug_CheckTorrent": false,
 	"debug_CheckPeer": false,

--- a/config.json
+++ b/config.json
@@ -66,7 +66,7 @@
     		"https://cdn.jsdelivr.net/gh/PBH-BTN/BTN-Collected-Rules@main/combine/all.txt"
 	],
 	"ipBlockListFile": [],
-	"enableShadowBan": true
+	"enableShadowBan": false
 	/*
 	"debug_CheckTorrent": false,
 	"debug_CheckPeer": false,

--- a/console.go
+++ b/console.go
@@ -274,7 +274,7 @@ func Task() {
 			}
 		}
 
-		SubmitBlockPeer(blockPeerMap)
+		SubmitBlockPeer(blockPeerMap, config.EnableShadowBan)
 
 		if !config.IPUploadedCheck && len(ipBlockListCompiled) <= 0 && len(ipBlockCIDRMapFromSyncServerCompiled) <= 0 {
 			Log("Task", GetLangText("Task_BanInfo"), true, blockCount, len(blockPeerMap))
@@ -343,7 +343,10 @@ func Stop() {
 	}
 
 	DeleteIPFilter()
-	SubmitBlockPeer(nil)
+	SubmitBlockPeer(nil, false)
+	if config.EnableShadowBan {
+		SubmitBlockPeer(nil, true)
+	}
 	httpClient.CloseIdleConnections()
 	httpClientWithoutCookie.CloseIdleConnections()
 	StopServer()


### PR DESCRIPTION
为**QBittorrent Enhanced Edition**用户提供一个开关，以在发现符合屏蔽规则的连接时，转为使用shadowban。
该开关在config.json中的名称为 **enableShadowBan** ，默认关闭，以防止影响其他客户端用户的使用。