### PR TITLE
添加ShadowBan选项

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -187,6 +187,7 @@ Docker version is configured through the same name variable configuration, which
 | banByRelativePUStartPrecent | float64 | 2 (%) | Enhanced automatic blocking_Relative/Start progress. If the relative upload progress of the client is greater than the set start progress, Peer will be automatically block |
 | banByRelativePUAntiErrorRatio | float64 | 3 (X) | Enhanced automatic blocking_Relative/Lag anti-misjudgment ratio. If the relative download progress obtained by the product of the relative download progress reported by the peer and the set ratio is lower than the relative upload progress of the client, Peer will be automatically block |
 | ignoreByDownloaded | uint32 | 100 (MB) | Enhanced automatic blocking*/Max downloaded. If downloaded from Peer is greater than this value, enhanced automatic blocking will be skipped |
+| ShadowBan | bool | false | Use Shadow Ban API block peers。This setting only works with client which has ShadowBan API.And it will check if Shadow Ban API available while loading config, with ignoring this setting if unavailabled.
 
 ## 反馈 Feedback
 User and developer can report bug through [Issue](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/issues), ask/discuss/share usage through [Discussion](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/discussions), contribute code improvement to blocker through [Pull Request](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/pulls).  

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Docker 版本通过相同名称的环境变量配置, 通过自动转换环境�
 | banByRelativePUStartPrecent | float64 | 2 (%) | 增强自动屏蔽_相对/起始进度. 若客户端相对上传进度大于设置起始进度, 则允许屏蔽 Peer |
 | banByRelativePUAntiErrorRatio | float64 | 3 (X) | 增强自动屏蔽_相对/滞后防误判倍率. 若 Peer 报告相对下载进度与设置倍率之乘积得到之相对下载进度 比 客户端相对上传进度 还低, 则允许屏蔽 Peer |
 | ignoreByDownloaded | uint32 | 100 (MB) | 增强自动屏蔽*/最高下载量. 若从 Peer 下载量大于此项, 则跳过增强自动屏蔽 |
+| ShadowBan | bool | false | 尝试使用Shadow Ban API进行封禁。仅对部分具有ShadowBan API的客户端生效，并会在载入配置时检测客户端相关API是否可用，若不可用则会忽略该参数。
 
 ## 反馈 Feedback
 用户及开发者可以通过 [Issue](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/issues) 反馈 bug, 通过 [Discussion](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/discussions) 提问/讨论/分享 使用方法, 通过 [Pull Request](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/pulls) 向客户端屏蔽器贡献代码改进.  

--- a/client.go
+++ b/client.go
@@ -126,7 +126,11 @@ func SubmitBlockPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
 
 	switch currentClientType {
 	case "qBittorrent":
-		return qB_SubmitBlockPeer(blockPeerMap)
+		if config.ShadowBan {
+			return qB_SubmitShadowBanPeer(blockPeerMap)
+		} else {
+			return qB_SubmitBlockPeer(blockPeerMap)
+		}
 	case "Transmission":
 		return Tr_SubmitBlockPeer(blockPeerMap)
 	}

--- a/client_qBittorrent.go
+++ b/client_qBittorrent.go
@@ -261,3 +261,81 @@ func qB_SubmitBlockPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
 
 	return true
 }
+
+func qb_GetPreferences() map[string]interface{} {
+	_, _, responseBody := Submit(config.ClientURL+"/v2/app/preferences", "", true, true, nil)
+	if responseBody == nil {
+		Log("Fail-GetQBPreferences", GetLangText("Fail-GetQBPreferences"), true)
+		return nil
+	}
+
+	var preferences map[string]interface{}
+	if err := json.Unmarshal(responseBody, &preferences); err != nil {
+		Log("Error-ParseQBPreferences", GetLangText("Error-Parse"), true, err.Error())
+		return nil
+	}
+
+	return preferences
+}
+
+func qb_TestShadowbanAPI() bool {
+	// 1. Check if enable_shadowban is true;
+	// enable_shadowban may be not exist in the preferences.
+	pref := qb_GetPreferences()
+	if pref == nil {
+		return false
+	}
+	
+	enableShadowban, ok := pref["shadow_ban_enabled"]
+	if !ok {
+		Log("Warn-ShadowbanAPINotExist", GetLangText("Warn-ShadowbanAPINotExist"), true)
+		return false
+	}
+	
+	if bEnableShadowban, ok := enableShadowban.(bool); ok {
+		if !bEnableShadowban {
+			return false
+		}
+	} else {
+		Log("Fail-UnknownShadowbanAPI", GetLangText("Fail-UnknownShadowbanAPI"), true)
+		return false
+	}
+
+	// 2. Check if the API is available
+	code, _, _ := Submit(config.ClientURL+"/v2/transfer/shadowbanPeers", "peers=", true, true, nil)
+	if code != 200 {
+		Log("Warn-ShadowbanAPINotExist", GetLangText("Warn-ShadowbanAPINotExist"), true)
+		return false
+	}
+	return true
+}
+
+func qB_SubmitShadowBanPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
+	shadowBanIPPortsList := []string{}
+	for peerIP, peerInfo := range blockPeerMap {
+		for port := range peerInfo.Port {
+			if port <=0 || port > 65535 {
+				port = 1 // Seems qBittorrent will ignore the invalid port number, so we just set it to 1.
+			}
+			shadowBanIPPortsList = append(shadowBanIPPortsList, peerIP + ":" + strconv.Itoa(port))
+		}
+	}
+	banIPPortsStr := strings.Join(shadowBanIPPortsList, "|")
+	Log("Debug-SubmitShadowBanPeer", "%s", false, banIPPortsStr)
+
+	var banResponseBody []byte
+
+	if banIPPortsStr != "" {
+		banIPPortsStr = url.QueryEscape(banIPPortsStr)
+		_, _, banResponseBody = Submit(config.ClientURL+"/v2/transfer/shadowbanPeers", "peers="+banIPPortsStr, true, true, nil)
+	} else {
+		return true
+	}
+
+	if banResponseBody == nil {
+		Log("SubmitShadowBanPeer", GetLangText("Error"), true)
+		return false
+	}
+
+	return true
+}

--- a/config.go
+++ b/config.go
@@ -80,6 +80,7 @@ type ConfigStruct struct {
 	BanByRelativePUStartMB        uint32
 	BanByRelativePUStartPrecent   float64
 	BanByRelativePUAntiErrorRatio float64
+	ShadowBan 			  bool
 }
 
 var programName = "qBittorrent-ClientBlocker"
@@ -194,6 +195,7 @@ var config = ConfigStruct{
 	BanByRelativePUStartMB:        20,
 	BanByRelativePUStartPrecent:   2,
 	BanByRelativePUAntiErrorRatio: 3,
+	ShadowBan: 			   false,
 }
 
 func SetBlockListFromContent(blockListContent []string, blockListSource string) int {
@@ -588,6 +590,12 @@ func LoadInitConfig(firstLoad bool) bool {
 	} else {
 		// 重置为上次使用的 URL, 主要目的是防止热重载配置文件可能破坏首次启动后从 qBittorrent 配置文件读取的 URL.
 		config.ClientURL = lastURL
+	}
+	if currentClientType == "qBittorrent" && config.ShadowBan {
+		if !qb_TestShadowbanAPI() {
+			Log("LoadInitConfig", GetLangText("Warn-EnableShadowbanReset"), true)
+			config.ShadowBan = false
+		}
 	}
 
 	if !firstLoad {

--- a/config.json
+++ b/config.json
@@ -72,6 +72,7 @@
 	"banByRelativePUStartMB": 20,
 	"banByRelativePUStartPrecent": 2.0,
 	"banByRelativePUAntiErrorRatio": 3.0,
-	"ignoreByDownloaded": 100
+	"ignoreByDownloaded": 100,
+	"ShadowBan": false,
 	*/
 }

--- a/i18n.go
+++ b/i18n.go
@@ -106,6 +106,13 @@ var defaultLangContent = map[string]string{
 	"Success-ClearBlockPeer":                           "已清理过期客户端: %d 个",
 	"Success-ExecCommand":                              "执行命令成功, 输出: %s",
 	"Success-SyncWithServer":                           "成功与同步服务器同步",
+
+// Shadowban Related
+	"Warn-ShadowbanAPINotExist": 						"Shadow Ban API 不存在，请确认使用的是具有 Shadow Ban 功能的客户端",
+	"Warn-EnableShadowbanReset":						"Shadow Ban API 未启用，已重置",
+	"Fail-GetQBPreferences":   							"获取qB偏好设置失败",
+	"Fail-UnknownShadowbanAPI":  						"Shadow Ban API 的类型超出预期",
+
 }
 
 func LoadLang(langCode string) bool {

--- a/i18n.go
+++ b/i18n.go
@@ -109,7 +109,7 @@ var defaultLangContent = map[string]string{
 
 // Shadowban Related
 	"Warn-ShadowbanAPINotExist": 						"Shadow Ban API 不存在，请确认使用的是具有 Shadow Ban 功能的客户端",
-	"Warn-EnableShadowbanReset":						"Shadow Ban API 未启用，已重置",
+	"Warn-EnableShadowbanReset":						"Shadow Ban API 未启用，已忽略 Shadow Ban配置",
 	"Fail-GetQBPreferences":   							"获取qB偏好设置失败",
 	"Fail-UnknownShadowbanAPI":  						"Shadow Ban API 的类型超出预期",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -94,5 +94,10 @@
 	"Success-Login": "Login successful",
 	"Success-ClearBlockPeer": "Cleaned up expired client: %d",
 	"Success-ExecCommand": "Exec command success, output: %s",
-	"Success-SyncWithServer": "Sync with server success"
+	"Success-SyncWithServer": "Sync with server success",
+
+	"Warn-ShadowbanAPINotExist": 						"Shadow Ban API is invalid, please double check if client has Shadow Ban feature",
+	"Warn-EnableShadowbanReset":						"Shadow Ban API is reset, ignore Shadow Ban setting",
+	"Fail-GetQBPreferences":   							"Failed to get qBittorrent preferences",
+	"Fail-UnknownShadowbanAPI":  						"Unknown Shadow Ban API value type"
 }


### PR DESCRIPTION
为qBittorrent Enhanced Edition 4.6.6.10及以上版本提供。配置文件内增加一个开关 **Shadowban**，启用后会尝试走qBEE的Shadowban API进行封禁。
载入配置时会对 Shadowban API进行可用性检测，如果检测认定不可用则会忽略该参数，请确保qBEE版本正确，且 **Connection->Shadow Ban Settings->Enable Shadow Ban** 为勾选状态。
目前使用正常，唉，希望没BUG。