### PR TITLE
修复一个问题，该问题使得shadowban功能无法处理ipv6地址

### DIFF
--- a/client_qBittorrent.go
+++ b/client_qBittorrent.go
@@ -316,7 +316,11 @@ func qB_SubmitShadowBanPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
 			if port <= 0 || port > 65535 {
 				port = 1 // Seems qBittorrent will ignore the invalid port number, so we just set it to 1.
 			}
-			shadowBanIPPortsList = append(shadowBanIPPortsList, peerIP + ":" + strconv.Itoa(port))
+			if IsIPv6(peerIP) { 
+				shadowBanIPPortsList = append(shadowBanIPPortsList,  "[" + peerIP + "]:" + strconv.Itoa(port))
+			} else {
+				shadowBanIPPortsList = append(shadowBanIPPortsList, peerIP + ":" + strconv.Itoa(port))
+			}
 		}
 	}
 


### PR DESCRIPTION
简单的说就是代码里没有处理ipv6的情景，导致生成了形如**1111::....::1111:1234**的地址格式。该格式不正确，但在提交给qbee后qbee不会返回任何错误响应，而是直接忽略并返回200。
修复后传递的[::]:xx格式能正常被qbee识别，但由于提交人没有v6环境，无法验证。