### PR TITLE
ShadowBan同步封禁 mapped IPv4 地址

### DIFF
--- a/client_qBittorrent.go
+++ b/client_qBittorrent.go
@@ -320,6 +320,7 @@ func qB_SubmitShadowBanPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
 				shadowBanIPPortsList = append(shadowBanIPPortsList,  "[" + peerIP + "]:" + strconv.Itoa(port))
 			} else {
 				shadowBanIPPortsList = append(shadowBanIPPortsList, peerIP + ":" + strconv.Itoa(port))
+				shadowBanIPPortsList = append(shadowBanIPPortsList, "[::ffff:" + peerIP + "]:" + strconv.Itoa(port))
 			}
 		}
 	}


### PR DESCRIPTION
接上一个pr[#127](https://github.com/Simple-Tracker/qBittorrent-ClientBlocker/pull/127)，在向qBEE提交ipv4地址时，额外提交对应的 ::ffff:\<ipv4 addr\> 地址。