### PR TITLE
Fix blocklist format for Transmission

### DIFF
--- a/client_Transmission.go
+++ b/client_Transmission.go
@@ -218,7 +218,7 @@ func Tr_FetchTorrents() *Tr_TorrentsStruct {
 func Tr_SubmitBlockPeer(blockPeerMap map[string]BlockPeerInfoStruct) bool {
 	ipfilterList := []string{}
 	for peerIP := range blockPeerMap {
-		ipfilterList = append(ipfilterList, peerIP)
+		ipfilterList = append(ipfilterList, ":" + peerIP + "-" + peerIP)
 	}
 
 	Tr_ipfilterStr = strings.Join(ipfilterList, "\n")


### PR DESCRIPTION
Transmission的[屏蔽列表](https://github.com/transmission/transmission/blob/main/docs/Blocklists.md#what-blocklist-does-transmission-use)需要[IP段](https://en.wikipedia.org/wiki/PeerGuardian#P2P_plaintext_format)，目前dev版本上提供给Transmission的屏蔽列表是一行一条IP记录，Transmission无法解析。